### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Interface.nuspec
+++ b/MakoIoT.Device.Services.Interface.nuspec
@@ -17,7 +17,7 @@
     <description>Interfaces for MAKO-IoT services (.NET nanoFramework C# projects).</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot interface</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.12.0" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.Interface/MakoIoT.Device.Services.Interface.nfproj
+++ b/src/MakoIoT.Device.Services.Interface/MakoIoT.Device.Services.Interface.nfproj
@@ -38,12 +38,13 @@
     <Compile Include="ObjectEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.12.0\lib\mscorlib.dll</HintPath>
-    </Reference>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/src/MakoIoT.Device.Services.Interface/packages.config
+++ b/src/MakoIoT.Device.Services.Interface/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.12.0" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.5.119" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.12.0 to 1.14.2</br>
[version update]

### :warning: This is an automated update. :warning:
