### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Interface.nuspec
+++ b/MakoIoT.Device.Services.Interface.nuspec
@@ -17,7 +17,7 @@
     <description>Interfaces for MAKO-IoT services (.NET nanoFramework C# projects).</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot interface</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.1" />
     </dependencies>
   </metadata>

--- a/src/MakoIoT.Device.Services.Interface/MakoIoT.Device.Services.Interface.nfproj
+++ b/src/MakoIoT.Device.Services.Interface/MakoIoT.Device.Services.Interface.nfproj
@@ -41,8 +41,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection">

--- a/src/MakoIoT.Device.Services.Interface/packages.config
+++ b/src/MakoIoT.Device.Services.Interface/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.14.2 to 1.15.5</br>
[version update]

### :warning: This is an automated update. :warning:
