### PR TITLE
Add TryGetConfigSection method to IConfigurationService

### DIFF
--- a/src/MakoIoT.Device.Services.Interface/IConfigurationService.cs
+++ b/src/MakoIoT.Device.Services.Interface/IConfigurationService.cs
@@ -5,6 +5,7 @@ namespace MakoIoT.Device.Services.Interface
     public interface IConfigurationService
     {
         object GetConfigSection(string sectionName, Type objectType);
+        bool TryGetConfigSection(string sectionName, Type objectType, out object section);
         void UpdateConfigSection(string sectionName, object section);
         bool UpdateConfigSectionString(string sectionName, string sectionString);
         bool UpdateConfigSectionString(string sectionName, string sectionString, Type objectType);


### PR DESCRIPTION
This update adds a new "TryGetConfigSection" method to the IConfigurationService interface. It retrieves a specific configuration section safely, without throwing an exception if the section doesn't exist, enhancing error handling capabilities.