### PR TITLE
Add IServer interface to Device Services

### DIFF
--- a/src/MakoIoT.Device.Services.Interface/IServer.cs
+++ b/src/MakoIoT.Device.Services.Interface/IServer.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace MakoIoT.Device.Services.Interface
+{
+    /// <summary>
+    /// Web server with Controllers support
+    /// </summary>
+    public interface IServer : IDisposable
+    {
+        /// <summary>
+        /// Starts web server.
+        /// </summary>
+        void Start();
+        
+        /// <summary>
+        /// Stops web server.
+        /// </summary>
+        void Stop();
+
+        /// <summary>
+        /// Initializes web server, register Controllers etc.
+        /// </summary>
+        void Initialize();
+    }
+}

--- a/src/MakoIoT.Device.Services.Interface/MakoIoT.Device.Services.Interface.nfproj
+++ b/src/MakoIoT.Device.Services.Interface/MakoIoT.Device.Services.Interface.nfproj
@@ -28,6 +28,7 @@
     <Compile Include="IDeviceStartBehavior.cs" />
     <Compile Include="ILog.cs" />
     <Compile Include="ILogSink.cs" />
+    <Compile Include="IServer.cs" />
     <Compile Include="ITask.cs" />
     <Compile Include="IDataProvider.cs" />
     <Compile Include="IDevice.cs" />


### PR DESCRIPTION
A new interface, IServer, was added to the MakoIoT Device Services Interface project. This interface provides the means for initializing, starting, and stopping a web server with Controllers support.