### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Interface.nuspec
+++ b/MakoIoT.Device.Services.Interface.nuspec
@@ -17,8 +17,8 @@
     <description>Interfaces for MAKO-IoT services (.NET nanoFramework C# projects).</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot interface</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.29" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.7" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.30" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.Interface/MakoIoT.Device.Services.Interface.nfproj
+++ b/src/MakoIoT.Device.Services.Interface/MakoIoT.Device.Services.Interface.nfproj
@@ -47,11 +47,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.29\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.30\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/src/MakoIoT.Device.Services.Interface/packages.config
+++ b/src/MakoIoT.Device.Services.Interface/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.17.1 to 1.17.7</br>Bumps nanoFramework.DependencyInjection from 1.1.29 to 1.1.30</br>
[version update]

### :warning: This is an automated update. :warning:
